### PR TITLE
[codex] Fix audit path and lifecycle issues

### DIFF
--- a/src/Monocle/Monocle.csproj
+++ b/src/Monocle/Monocle.csproj
@@ -445,7 +445,7 @@
 		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
 		<PackageReference Include="NUnit" Version="2.6.3" />
 		<PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
-		<PackageReference Include="Extended.Wpf.Toolkit" Version="2.2.0" />
+		<PackageReference Include="Extended.Wpf.Toolkit" Version="4.3.0" />
 	</ItemGroup>
 	<ItemGroup Condition="'$(TargetFramework)' == 'net8.0-windows' Or '$(TargetFramework)' == 'net10.0-windows'">
 		<PackageReference Include="CommonServiceLocator" Version="2.0.7" />

--- a/src/Monocle/MonocleViewExtension.cs
+++ b/src/Monocle/MonocleViewExtension.cs
@@ -31,9 +31,11 @@ namespace MonocleViewExtension
         public string UniqueId => "5A256B35-BD09-423C-82A1-372957143927";
         public string Name => "Monocle View Extension";
 
+        private StandardViewsViewModel standardViewsViewModel;
 
         public void Dispose()
         {
+            standardViewsViewModel?.Dispose();
             AppDomain.CurrentDomain.AssemblyResolve -= CurrentDomainOnAssemblyResolve;
 #if net8 || net10
             System.Runtime.Loader.AssemblyLoadContext.Default.Resolving -= AssemblyLoadContext_Resolving;
@@ -129,7 +131,7 @@ namespace MonocleViewExtension
             InlineNodeConnectomaticCommand.AddMenuItem(p, monocleMenuItem);
             SimpleSearchCommand.AddMenuItem(p, monocleMenuItem, this);
             //TODO: Check if standard views consistently loads on different file changes
-            StandardViewsCommand.EnableStandardViews(p);
+            standardViewsViewModel = StandardViewsCommand.EnableStandardViews(p);
             MonocleSettingsCommand.AddMenuItem(monocleMenuItem);
             FancyPasteCommand.AddMenuItem(p);
             BetterSaveCommand.AddMenuItem(p);

--- a/src/Monocle/StandardViews/StandardViewsCommand.cs
+++ b/src/Monocle/StandardViews/StandardViewsCommand.cs
@@ -13,7 +13,7 @@ namespace MonocleViewExtension.StandardViews
         /// Enable Standard Views in canvas
         /// </summary>
         /// <param name="p">our view loaded parameters for dynamo</param>
-        public static void EnableStandardViews(ViewLoadedParams p)
+        public static StandardViewsViewModel EnableStandardViews(ViewLoadedParams p)
         {
             var m = new StandardViewsModel(p);
             var vm = new StandardViewsViewModel(m);
@@ -27,6 +27,7 @@ namespace MonocleViewExtension.StandardViews
 
             vm.ViewControlPanel = statusBarPanel;
 
+            return vm;
         }
 
 

--- a/src/Monocle/StandardViews/StandardViewsViewModel.cs
+++ b/src/Monocle/StandardViews/StandardViewsViewModel.cs
@@ -92,6 +92,13 @@ namespace MonocleViewExtension.StandardViews
             }
         }
 
+        public override void Dispose()
+        {
+            Model.LoadedParams.SelectionCollectionChanged -= LoadedParamsOnSelectionCollectionChanged;
+            ViewControlPanel?.Children.Remove(View);
+            base.Dispose();
+        }
+
 
         #region Helpers
         public IEnumerable<T> FindVisualChildren<T>(DependencyObject depObj) where T : DependencyObject

--- a/src/Monocle/Utilities/Globals.cs
+++ b/src/Monocle/Utilities/Globals.cs
@@ -21,7 +21,7 @@ namespace MonocleViewExtension.Utilities
 
         public static string TempPath = Path.GetTempPath();
         public static string ExecutingPath = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-        public static string ExtraFolder = ExecutingPath.Replace("bin", "extra");
+        public static string ExtraFolder = Path.Combine(Directory.GetParent(ExecutingPath)?.FullName, "extra");
         public static string SettingsFile = Path.Combine(ExtraFolder, "MonocleSettings.xml");
 
         public static bool IsFocaEnabled { get; set; } = true;

--- a/src/Monocle/app.config
+++ b/src/Monocle/app.config
@@ -9,7 +9,7 @@
     <assemblyBinding xmlns="urn:schemas-microsoft-com:asm.v1">
       <dependentAssembly>
         <assemblyIdentity name="System.Collections.Immutable" publicKeyToken="b03f5f7f11d50a3a" culture="neutral" />
-        <bindingRedirect oldVersion="0.0.0.0-1.2.5.0" newVersion="1.2.5.0" />
+        <bindingRedirect oldVersion="0.0.0.0-8.0.0.0" newVersion="8.0.0.0" />
       </dependentAssembly>
       <dependentAssembly>
         <assemblyIdentity name="System.Windows.Interactivity" publicKeyToken="31bf3856ad364e35" culture="neutral" />

--- a/src/MonocleLoader/MonocleExtension/Global.cs
+++ b/src/MonocleLoader/MonocleExtension/Global.cs
@@ -10,8 +10,8 @@ namespace MonocleExtension
         internal static Assembly ExecutingAssembly = Assembly.GetExecutingAssembly();
 
         internal static string PackageBinFolder => Path.GetDirectoryName(ExecutingAssembly.Location);
-        internal static string PackageExtraFolder => PackageBinFolder.Replace("bin", "extra");
-        internal static string PackageRoot => PackageBinFolder.Replace("bin", "");
+        internal static string PackageRoot => Directory.GetParent(PackageBinFolder)?.FullName;
+        internal static string PackageExtraFolder => Path.Combine(PackageRoot, "extra");
         internal static string MonocleViewExtensionDll => Path.Combine(PackageBinFolder, "MonocleViewExtension.dll");
 
         internal static string ViewExtensionXml => Path.Combine(PackageExtraFolder, "Monocle_ViewExtensionDefinition.xml");


### PR DESCRIPTION
# Summary

- Replace broad `bin` string replacement with parent-folder path construction for package `extra` paths.
- Dispose the Standard Views view model from the extension lifecycle so its selection event handler is unsubscribed and the injected view is removed.
- Align net48 Extended.Wpf.Toolkit to 4.3.0 and update the System.Collections.Immutable binding redirect to match the referenced package.

# Validation

- `dotnet restore src\Monocle\Monocle.sln`
- `dotnet build src\Monocle\Monocle.sln --no-restore -v:minimal`

Build succeeds with 5 existing warnings remaining: the net48 HelixToolkit.Wpf.SharpDX reference still conflicts with Dynamo 2.0 transitive metadata, and Foca uses obsolete Dynamo APIs. The Xceed and System.Collections.Immutable warnings from the audit are resolved.
